### PR TITLE
updated for new daq-cmake

### DIFF
--- a/cmake/loggingConfig.cmake.in
+++ b/cmake/loggingConfig.cmake.in
@@ -3,28 +3,25 @@
 
 include(CMakeFindDependencyMacro)
 
-# Insert find_dependency() calls for your package's dependencies in
-# the place of this comment. Make sure they match up with the
-# find_package calls in your package's CMakeLists.txt file
 find_dependency(ers)
 find_dependency(Boost COMPONENTS unit_test_framework program_options)
 find_dependency(TRACE)
-
-
-
-# Figure out whether or not this dependency is an installed package or
-# in repo form
 
 if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
 
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
 add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@)
 
+# Compute paths
+set(@PROJECT_NAME@_DAQSHARE "${CMAKE_CURRENT_LIST_DIR}")
+
 else()
 
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as installed package (found in ${CMAKE_CURRENT_LIST_DIR})")
 set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
 include(${targets_file})
+
+set(@PROJECT_NAME@_DAQSHARE "${CMAKE_CURRENT_LIST_DIR}/../../../share")
 
 endif()
 


### PR DESCRIPTION
This PR modifies the cmake config in order to work with the daq-cmake planned for v2.3.0 (develop now).