### PR TITLE
A few small tweaks to the README file

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,20 +6,21 @@ The primary user documentation starting point for the DUNE fork of ERS is found 
 One link to TRACE information can be found [here](https://cdcvs.fnal.gov/redmine/projects/trace/wiki).
 
 ERS provides:
-- Assertion Macros
-- Macros for declaring Custom Issues
-- 6 logging streams and corresponding methods to work with (i.e. send to) them.
-- a mechanism to configure destination(s) for each of 6 loggings streams
+* Assertion Macros
+* Macros for declaring Custom Issues
+* 6 logging streams and corresponding methods to work with (i.e. send to) them.
+* a mechanism to configure destination(s) for each of 6 loggings streams
 
 ERS also provides Logging Macros, but these have been removed in the DUNE DAQ fork.
 
 TRACE provides:
-- several macros to implement stream-style logging to different logging levels.
-- slow and fast-path logging
-- a mechanism to configure the slow-path logging, i.e to use ERS as the slow-path logging.
+* several macros to implement stream-style logging to different logging levels.
+* slow and fast-path logging (where "fast" corresponds to a memory-mapped file and "slow" corresponds to the console, a disk file, or another slower destination)
+* a mechanism to configure the slow-path logging, i.e to use ERS as the slow-path logging.
 
-<details><summary>One of the ERS *destinations* for first 4 of the 6 loggings
-*streams* will be a "TRACE fast path destination."</summary>
+<details><summary>All messages that are sent to one of the ERS streams will also be sent to the TRACE fast path.</summary>
+This is achieved by specifying one of the ERS *destinations* for first 4 of the 6 loggings
+*streams* to be the "TRACE fast path destination."
 The Logging package setup function will ensure that the environment variables DUNEDAQ_ERS_{FATAL,ERROR,WARNING,INFO} (used to configure the stream destinations) will contain the "TRACE fast path destination." It is expected/required that all applications will call the Logging package setup function.</details>
 
 Only two of the TRACE logging macros (TLOG() and TLOG_DEBUG()) will be used and TRACE will be configured to use ERS for the slow-path logging.


### PR DESCRIPTION
1. I noticed that on ReadTheDocs, the bullet points early on the page are not being rendered correctly, so I tried switching from dashes to asterisks.  Hopefully, that helps.
2. I added some parenthetical text that tries to give a little bit of information about what the TRACE fast and slow paths mean.
3. The summary statement that talked about ERS destinations being mapped to the TRACE fast path seemed like it might be hard for an uninitiated user to understand.  So, I tried moving that statement into the detailed text and put a statement that had less jargon in the summary.