### PR TITLE
set destructor to public, and remove () when initializing object with…

### DIFF
--- a/test/apps/exception_example.cxx
+++ b/test/apps/exception_example.cxx
@@ -21,12 +21,13 @@ where <num> is a number: 0 - 6.
 
 class XX
 {
+    public:
 	~XX() { TLOG_DEBUG(1) << "dtor object after raise/throw"; }
 };
 
 void foo( int except_int )
 {
-	XX xx();
+	XX xx;
 	switch( except_int ) {
 	case 0: {
 		TLOG_DEBUG(1) << "raising ers::PermissionDenied " << "somefilename";


### PR DESCRIPTION
… default values

This is to fix the following compiler warnings:

```
/__w/daq-release/daq-release/dev-c7/sourcecode/logging/test/apps/exception_example.cxx:29:14: warning: empty parentheses were disambiguated as a function declaration [-Wvexing-parse]
[598](https://github.com/DUNE-DAQ/daq-release/actions/runs/4444362668/jobs/7802501591#step:6:599)
   29 |         XX xx();
[599](https://github.com/DUNE-DAQ/daq-release/actions/runs/4444362668/jobs/7802501591#step:6:600)
      |              ^~
[600](https://github.com/DUNE-DAQ/daq-release/actions/runs/4444362668/jobs/7802501591#step:6:601)
/__w/daq-release/daq-release/dev-c7/sourcecode/logging/test/apps/exception_example.cxx:29:14: note: remove parentheses to default-initialize a variable
[601](https://github.com/DUNE-DAQ/daq-release/actions/runs/4444362668/jobs/7802501591#step:6:602)
   29 |         XX xx();
[602](https://github.com/DUNE-DAQ/daq-release/actions/runs/4444362668/jobs/7802501591#step:6:603)
      |              ^~
[603](https://github.com/DUNE-DAQ/daq-release/actions/runs/4444362668/jobs/7802501591#step:6:604)
      |              --
[604](https://github.com/DUNE-DAQ/daq-release/actions/runs/4444362668/jobs/7802501591#step:6:605)
/__w/daq-release/daq-release/dev-c7/sourcecode/logging/test/apps/exception_example.cxx:29:14: note: or replace parentheses with braces to aggregate-initialize a variable
```


https://github.com/DUNE-DAQ/daq-release/actions/runs/4444362668/jobs/7802501591#step:6:598